### PR TITLE
Fix Unauthorized ADB Devices

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -28,7 +28,7 @@ endif
 
 ifneq ($(TARGET_BUILD_VARIANT),eng)
 # Enable ADB authentication
-ADDITIONAL_DEFAULT_PROPERTIES += ro.adb.secure=1
+ADDITIONAL_DEFAULT_PROPERTIES += ro.adb.secure=0
 endif
 
 # Backup Tool


### PR DESCRIPTION
Changed ro.adb.secure from 1 to 0 to allow connections in Recovery